### PR TITLE
Protect ticket purchase from invalid user input

### DIFF
--- a/FitNesseRoot/OnlineLottery.wiki
+++ b/FitNesseRoot/OnlineLottery.wiki
@@ -4,3 +4,4 @@ PrizeCalculation
 PlayerRegistration
 PurchaseTicket
 PurchaseTicketNotEnoughMoney
+PurchaseTicketInvalidUserInputs

--- a/FitNesseRoot/PurchaseTicket.wiki
+++ b/FitNesseRoot/PurchaseTicket.wiki
@@ -11,17 +11,12 @@ OnlineLottery
 |OnlineLottery.Test.PurchaseTicket|
 
 |Set Up Test Environment|
-|Create Draw|
-|01.01.2017|
-
-|Player Registers|
-|Username|Password|Name|Address|City|Postcode|Country|Player Id?|
-|john|test123|John Smith|44 Ranelagh Way|London|NN1EE1|UK|>>player|
+|Create Draw|01.01.2017|
+|New Player|john|registers and deposits|100|dollars|
 
 !3 A player registers, transfers money into the account and purchases a ticket. The ticket should be registered for the correct draw in the system, and the account balance and pool size will be adjusted for the ticket value
 
 |Purchase Ticket|
-|Player|john|Deposits|100|dollars with card|4111111111111111|and expiry date|01/18|
 |Player|john|has|100|dollars|
 |Player|john|buys a ticket with numbers|1,3,4,5,8,10| for draw on|01.01.2017|
 |Check|Pool value for draw on|01.01.2017|is|10|

--- a/FitNesseRoot/PurchaseTicketInvalidUserInputs.wiki
+++ b/FitNesseRoot/PurchaseTicketInvalidUserInputs.wiki
@@ -1,0 +1,33 @@
+---
+Test
+---
+OnlineLottery
+
+!define COMMAND_PATTERN {%m -r fitnesse.fitserver.FitServer,dotnet2\fit.dll %p}
+!define TEST_RUNNER {dotnet2\Runner.exe}
+!path ${RootPath}\OnlineLottery\bin\Release\OnlineLottery.dll
+
+!|import|
+|OnlineLottery.Test.PurchaseTicket|
+
+|Set Up Test Environment|
+|Create Draw|01.01.2017|
+|New player|john|registers and deposits|50|dollars|
+
+!3 When a user selects more or less than six numbers, the ticket purchase should be refused. The ticket should not be registered, account balance and pool value remain untouched.
+
+|Purchase Ticket|
+|reject|Player|john|buys a ticket with numbers|1,3,4,5,8| for draw on|01.01.2017|
+|reject|Player|john|buys a ticket with numbers|1,3,4,5,8,10,13| for draw on|01.01.2017|
+|Check|Pool value for draw on|01.01.2017|is|0|
+|Check|Account balance for|john|is|50|
+|not|Ticket with numbers|1,3,4,5,8|for|10|dollars is registered for player|john|for draw on|01.01.2017|
+|not|Ticket with numbers|1,3,4,5,8,10,13|for|10|dollars is registered for player|john|for draw on|01.01.2017|
+
+!3 When a user selects a negative amount of tickets, the ticket purchase should be refused. The ticket should not be registered, account balance and pool value remain untouched.
+
+|Purchase Ticket|
+|reject|Player|john|buys|-2|tickets with numbers|1,3,4,5,8,10| for draw on|01.01.2017|
+|Check|Pool value for draw on|01.01.2017|is|0|
+|Check|Account balance for|john|is|50|
+|not|Ticket with numbers|1,3,4,5,8,10|for|-20|dollars is registered for player|john|for draw on|01.01.2017|

--- a/FitNesseRoot/PurchaseTicketNotEnoughMoney.wiki
+++ b/FitNesseRoot/PurchaseTicketNotEnoughMoney.wiki
@@ -11,17 +11,13 @@ OnlineLottery
 |OnlineLottery.Test.PurchaseTicket|
 
 |Set Up Test Environment|
-|Create Draw|
-|01.01.2017|
-
-|Player Registers|
-|Username|Password|Name|Address|City|Postcode|Country|Player Id?|
-|john|test123|John Smith|44 Ranelagh Way|London|NN1EE1|UK|>>player|
+|Create Draw|01.01.2017|
+|New player|john|registers and deposits|50|dollars|
 
 !3 When there is not enough money in the account, the ticket purchase should be refused. The ticket should not be registered, account balance and pool value remain untouched.
 
 |Purchase Ticket|
-|Player|john|Deposits|50|dollars with card|4111111111111111|and expiry date|01/18|
+|Player|john|has|50|dollars|
 |reject|Player|john|buys|10|tickets with numbers|1,3,4,5,8,10| for draw on|01.01.2017|
 |Check|Pool value for draw on|01.01.2017|is|0|
 |Check|Account balance for|john|is|50|

--- a/FitNesseRoot/RecentChanges.wiki
+++ b/FitNesseRoot/RecentChanges.wiki
@@ -1,6 +1,7 @@
-|PurchaseTicketNotEnoughMoney||23:54:35 Di, Apr 04, 2017|
-|OnlineLottery||23:45:48 Di, Apr 04, 2017|
-|PurchaseTicket||23:41:00 Di, Apr 04, 2017|
+|PurchaseTicketInvalidUserInputs||22:21:46 Mi, Apr 05, 2017|
+|OnlineLottery||22:11:13 Mi, Apr 05, 2017|
+|PurchaseTicket||22:03:01 Mi, Apr 05, 2017|
+|PurchaseTicketNotEnoughMoney||22:02:13 Mi, Apr 05, 2017|
 |PlayerRegistration||21:30:45 Di, Apr 04, 2017|
 |PrizeCalculation||21:30:32 Di, Apr 04, 2017|
 |FrontPage||23:07:14 So, Apr 02, 2017|

--- a/OnlineLottery/DrawManager.cs
+++ b/OnlineLottery/DrawManager.cs
@@ -28,6 +28,8 @@ namespace OnlineLottery
         public void PurchaseTicket(DateTime drawDate, int playerId, int[] numbers, decimal value)
         {
             if (!_draws.ContainsKey(drawDate)) throw new DrawNotOpenException();
+            if(numbers.Length != 6) throw new WrongAmountOfNumbersException();
+            if(value < 0) throw new InvalidPurchaseException();
 
             var d = _draws[drawDate];
             var player = _playerManager.GetPlayer(playerId);

--- a/OnlineLottery/IDrawManager.cs
+++ b/OnlineLottery/IDrawManager.cs
@@ -7,6 +7,16 @@ namespace OnlineLottery
         public DrawNotOpenException() : base("Draw is not open") { }
     }
 
+    public class WrongAmountOfNumbersException : ApplicationException
+    {
+        public WrongAmountOfNumbersException() : base("A ticket needs 6 numbers") { }
+    }
+
+    public class InvalidPurchaseException : ApplicationException
+    {
+        public InvalidPurchaseException() : base("Purchase declined") { }
+    }
+
     public interface IDrawManager
     {
         IDraw GetDraw(DateTime date);

--- a/OnlineLottery/Test/PurchaseTicket.cs
+++ b/OnlineLottery/Test/PurchaseTicket.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Linq;
-using fit;
 using fitlibrary;
 
 namespace OnlineLottery.Test.PurchaseTicket
 {
-    public class SetUpTestEnvironment : ColumnFixture
+    public class SetUpTestEnvironment : DoFixture
     {
         internal static IPlayerManager PlayerManager;
         internal static IDrawManager DrawManager;
@@ -20,17 +19,12 @@ namespace OnlineLottery.Test.PurchaseTicket
         {
             set { DrawManager.CreateDraw(value); }
         }
-    }
 
-    public class PlayerRegisters : ColumnFixture
-    {
-        public class ExtendedPlayerRegistrationInfo : PlayerRegistrationInfo
+        public void NewPlayerRegistersAndDepositsDollars(string username, decimal amount)
         {
-            public int PlayerId() => SetUpTestEnvironment.PlayerManager.RegisterPlayer(this);
+            var pid = PlayerManager.RegisterPlayer(new PlayerRegistrationInfo {Username = username});
+            PlayerManager.DepositWithCard(pid, "11111111", "01/01", amount);
         }
-
-        private readonly ExtendedPlayerRegistrationInfo _extendedRegInfo = new ExtendedPlayerRegistrationInfo();
-        public override object GetTargetObject() => _extendedRegInfo;
     }
 
     public class PurchaseTicket : DoFixture
@@ -38,17 +32,9 @@ namespace OnlineLottery.Test.PurchaseTicket
         private readonly IDrawManager _drawManager = SetUpTestEnvironment.DrawManager;
         private readonly IPlayerManager _playerManager = SetUpTestEnvironment.PlayerManager;
 
-        public void PlayerDepositsDollarsWithCardAndExpiryDate(
-            string username, decimal amount,
-            string card, string expiry)
-        {
-            var pid = _playerManager.GetPlayer(username).PlayerId;
-            _playerManager.DepositWithCard(pid, card, expiry, amount);
-        }
-
         public bool PlayerHasDollars(string username, decimal amount) => _playerManager.GetPlayer(username).Balance == amount;
 
-        public void PlayerBuysTicketsWithNumbersForDranOn(string username, int tickets, int[] numbers, DateTime drawDate)
+        public void PlayerBuysTicketsWithNumbersForDrawOn(string username, int tickets, int[] numbers, DateTime drawDate)
         {
             PurchaseTickets(username, tickets, numbers, drawDate);
         }


### PR DESCRIPTION
- There must be exactly 6 numbers in ticket
- Cannot buy a negative amount of tickets
- Cleaned up PurchaseTicket tests with a utility fixture for registering a player with a start deposit